### PR TITLE
Fixes a path on DeForest Wall Med-Vendor

### DIFF
--- a/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
+++ b/modular_skyrat/modules/deforest_medical_items/code/medstation_designs/medical.dm
@@ -91,7 +91,7 @@
 	id = "organic_repair_foam"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 100)
-	build_path = /obj/item/stack/sticky_tape/surgical
+	build_path = /obj/item/stack/medical/wound_recovery/robofoam
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_DEFOREST_MEDICAL,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There was an erroneous path on the wall med vendor, resulting in 2 options for tape when one should be foam.

## How This Contributes To The Skyrat Roleplay Experience

You can actually print the item that is listed, instead of getting more tape...

## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>

![image](https://github.com/xXPawnStarrXx/Skyrat-tg/assets/53197594/a3bd4567-f071-4951-8dfb-58c11fc4cd47)
 
![image](https://github.com/xXPawnStarrXx/Skyrat-tg/assets/53197594/5f530330-09fb-4f20-aaf5-ef5ab76b0e04)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed an erroneous path
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
